### PR TITLE
Main page mobile view

### DIFF
--- a/index.css
+++ b/index.css
@@ -35,39 +35,53 @@
         grid-template-rows: 400px 200px 200px;
     }
 
+    .forecast-container .forecast .forecast-content {
+        padding-top: 15px;
+    }
+
+    .forecast-container :not(.today).forecast .forecast-icon {
+        margin-bottom: 0;
+    }
+
     #f0 {
         grid-row: 1;
         grid-column: 1 / span 3;
     }
 
     #f1 {
-        grid-row: 2;
-        grid-column: 1;
+        grid-row: 2 / span 1;
+        grid-column: 1 / span 1;
+        width: auto;
     }
 
     #f2 {
         grid-row: 2;
         grid-column: 2;
+        width: auto;
     }
 
     #f3 {
         grid-row: 2;
         grid-column: 3;
+        width: auto;
     }
 
     #f4 {
         grid-row: 3;
         grid-column: 1;
+        width: auto;
     }
 
     #f5 {
         grid-row: 3;
         grid-column: 2;
+        width: auto;
     }
 
     #f6 {
         grid-row: 3;
         grid-column: 3;
+        width: auto;
     }
 
     /* body {

--- a/index.css
+++ b/index.css
@@ -18,3 +18,10 @@
     border-radius: 10px;
     font-size: 20px;
 }
+
+/* UI break point */
+@media (max-width: 520px) {
+    /* body {
+        background-color: white;
+    } */
+}

--- a/index.css
+++ b/index.css
@@ -19,16 +19,24 @@
     font-size: 20px;
 }
 
-/* UI break point */
+/* Daily weather on the right */
 @media (min-width: 901px) {
     .forecast-header {
         min-height: 49px;
     }
 }
 
-
-/* UI break point */
+/* Mobile view */
 @media (max-width: 520px) {
+    .fullwidth-block {
+        padding-left: 5vw;
+        padding-right: 1vw;
+    }
+
+    .colophon {
+        margin-top: 7px;
+    }
+
     .forecast-container {
         display: grid;
         grid-template-columns: 33.33% 33.33% auto;

--- a/index.css
+++ b/index.css
@@ -39,7 +39,7 @@
 
     .forecast-container {
         display: grid;
-        grid-template-columns: 1fr 1fr 1fr;
+        grid-template-columns: 33.33% 33.33% auto;
         grid-template-rows: 400px 200px 200px;
     }
 

--- a/index.css
+++ b/index.css
@@ -31,7 +31,7 @@
 @media (max-width: 520px) {
     .forecast-container {
         display: grid;
-        grid-template-columns: 33% 33% 33%;
+        grid-template-columns: 33.33% 33.33% auto;
         grid-template-rows: 400px 200px 200px;
     }
 

--- a/index.css
+++ b/index.css
@@ -29,6 +29,47 @@
 
 /* UI break point */
 @media (max-width: 520px) {
+    .forecast-container {
+        display: grid;
+        grid-template-columns: 33% 33% 33%;
+        grid-template-rows: 400px 200px 200px;
+    }
+
+    #f0 {
+        grid-row: 1;
+        grid-column: 1 / span 3;
+    }
+
+    #f1 {
+        grid-row: 2;
+        grid-column: 1;
+    }
+
+    #f2 {
+        grid-row: 2;
+        grid-column: 2;
+    }
+
+    #f3 {
+        grid-row: 2;
+        grid-column: 3;
+    }
+
+    #f4 {
+        grid-row: 3;
+        grid-column: 1;
+    }
+
+    #f5 {
+        grid-row: 3;
+        grid-column: 2;
+    }
+
+    #f6 {
+        grid-row: 3;
+        grid-column: 3;
+    }
+
     /* body {
         background-color: white;
     } */

--- a/index.css
+++ b/index.css
@@ -20,6 +20,14 @@
 }
 
 /* UI break point */
+@media (min-width: 901px) {
+    .forecast-header {
+        min-height: 49px;
+    }
+}
+
+
+/* UI break point */
 @media (max-width: 520px) {
     /* body {
         background-color: white;

--- a/index.css
+++ b/index.css
@@ -28,6 +28,10 @@
 
 /* Mobile view */
 @media (max-width: 520px) {
+    #f0>div.forecast-content>div.degree>div.num {
+        font-size: 20vw;
+    }
+
     .fullwidth-block {
         padding-left: 5vw;
         padding-right: 1vw;
@@ -90,5 +94,11 @@
         grid-row: 3;
         grid-column: 3;
         width: auto;
+    }
+}
+
+@media (max-width: 380px) {
+    #f0>div.forecast-content>div.degree>div.num {
+        font-size: 15vw;
     }
 }

--- a/index.css
+++ b/index.css
@@ -39,7 +39,7 @@
 
     .forecast-container {
         display: grid;
-        grid-template-columns: 33.33% 33.33% auto;
+        grid-template-columns: 1fr 1fr 1fr;
         grid-template-rows: 400px 200px 200px;
     }
 

--- a/index.css
+++ b/index.css
@@ -91,8 +91,4 @@
         grid-column: 3;
         width: auto;
     }
-
-    /* body {
-        background-color: white;
-    } */
 }

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
 		<div class="forecast-table">
 			<div class="container">
 				<div class="forecast-container">
-					<div class="today forecast">
+					<div id="f0" class="today forecast">
 						<div class="forecast-header">
 							<div class="day">Monday</div>
 							<div class="date">6 Oct</div>
@@ -82,7 +82,7 @@
 							<span><img src="images/icon-compass.png" alt="">East</span>
 						</div>
 					</div>
-					<div class="forecast">
+					<div id="f1" class="forecast">
 						<div class="forecast-header">
 							<div class="day">Tuesday</div>
 						</div> <!-- .forecast-header -->
@@ -94,7 +94,7 @@
 							<small>18<sup>o</sup></small>
 						</div>
 					</div>
-					<div class="forecast">
+					<div id="f2" class="forecast">
 						<div class="forecast-header">
 							<div class="day">Wednesday</div>
 						</div> <!-- .forecast-header -->
@@ -106,7 +106,7 @@
 							<small>18<sup>o</sup></small>
 						</div>
 					</div>
-					<div class="forecast">
+					<div id="f3" class="forecast">
 						<div class="forecast-header">
 							<div class="day">Thursday</div>
 						</div> <!-- .forecast-header -->
@@ -118,7 +118,7 @@
 							<small>18<sup>o</sup></small>
 						</div>
 					</div>
-					<div class="forecast">
+					<div id="f4" class="forecast">
 						<div class="forecast-header">
 							<div class="day">Friday</div>
 						</div> <!-- .forecast-header -->
@@ -130,7 +130,7 @@
 							<small>18<sup>o</sup></small>
 						</div>
 					</div>
-					<div class="forecast">
+					<div id="f5" class="forecast">
 						<div class="forecast-header">
 							<div class="day">Saturday</div>
 						</div> <!-- .forecast-header -->
@@ -142,7 +142,7 @@
 							<small>18<sup>o</sup></small>
 						</div>
 					</div>
-					<div class="forecast">
+					<div id="f6" class="forecast">
 						<div class="forecast-header">
 							<div class="day">Sunday</div>
 						</div> <!-- .forecast-header -->


### PR DESCRIPTION
## Summary

Changed layout on mobile devices. Forecasts for upcoming days were split into **two rows** containing 3 days form single 6 element row.  
Every element was assigned `id` and they were aligned by using CCS **grid layout**.  
This layout affects only mobile view thanks to CSS **media query**.

Closes #6

## Comparison

| Before | After |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/19330758/70374072-2f6acc00-18ef-11ea-88c2-f70321ea34bf.png)   |  ![image](https://user-images.githubusercontent.com/19330758/70374113-aa33e700-18ef-11ea-8b7d-d20e472f5538.png)    |

## Additional changes

On the desktop view (the widest one) weather headings now have the same minimum height.

On the mobile view more padding from the sides were added.

-------------

Branch can be safely **deleted** after merge 💣